### PR TITLE
feat: enable headful browsing

### DIFF
--- a/example.gpt
+++ b/example.gpt
@@ -1,15 +1,18 @@
 Tools: sys.read, browse-html, search-and-query
 
 Browse the website at www.bing.com, search and query the result using keyword `acorn labs`.
+If a site presents a challenge to access, retry in headful mode.
+
 
 ---
 name: browse-html
-description: browse and summarise website html
+description: browse a website
 args: website: the website url to browse. The url should have https protocol prepend.
+args: headful: set to true to browse in headful mode. Default is false (headless).
 
 #!/bin/bash
 
-npx ts-node html-clean.ts ${website}
+npx ts-node html-clean.ts ${website} ${headful}
 
 ---
 name: search-and-query

--- a/html-clean.ts
+++ b/html-clean.ts
@@ -4,12 +4,16 @@ import * as cheerio from 'cheerio'
 async function main (): Promise<void> {
   const args = process.argv.slice(2)
 
+  let headful = false
   const website = args[0]
+  if (args.length > 1) {
+    headful = args[1] === 'true'
+  }
 
   const context = await chromium.launchPersistentContext(
     '',
     {
-      headless: true,
+      headless: !headful,
       channel: 'chrome'
     })
   const page = await context.newPage()


### PR DESCRIPTION
Add a second argument to `html-clean.ts` to enable "headful" browsing, enabling the tool get content on sites that restrict headless access.

e.g.

```sh
npx ts-node html-clean.ts https://platform.openai.com/docs/api-reference/assistants true
```