### PR TITLE
enhance: add a filtering mechanism

### DIFF
--- a/src/browse.ts
+++ b/src/browse.ts
@@ -106,7 +106,7 @@ export async function filterContent (page: Page, tabID: string, printTabID: bool
       filteredContent += $.html(elem);
     });
   } else {
-    throw new Error(`Invalid filter format: ${filter}. Use a valid CSS selector.`);
+    throw new Error(`Invalid filter format: ${filter}. Use a CSS ID, class, or tag selector.`);
   }
 
   // Clean up the filtered content

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,7 @@ import express, { type Request, type Response } from 'express'
 import bodyParser from 'body-parser'
 import { type BrowserContext, type Page } from 'playwright'
 import { chromium } from 'playwright'
-import { browse, close } from './browse'
+import { browse, close, filterContent } from './browse'
 import { click } from './click'
 import { fill } from './fill'
 import { enter } from './enter'
@@ -44,6 +44,7 @@ async function main (): Promise<void> {
     const website: string = data.website ?? ''
     const userInput: string = data.userInput ?? ''
     const keywords: string[] = (data.keywords ?? '').split(',')
+    const filter: string = data.filter ?? ''
 
     if (process.env.GPTSCRIPT_WORKSPACE_ID === undefined || process.env.GPTSCRIPT_WORKSPACE_DIR === undefined) {
       res.status(400).send('GPTScript workspace ID and directory are not set')
@@ -138,6 +139,8 @@ async function main (): Promise<void> {
     if (req.path === '/browse') {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       res.send(await browse(page, website, 'browse', tabID, printTabID, settings))
+    } else if (req.path === '/getFilteredContent') {
+      res.send(await filterContent(page, tabID, printTabID, filter, settings))
     } else if (req.path === '/getPageContents') {
       res.send(await browse(page, website, 'getPageContents', tabID, printTabID, settings))
     } else if (req.path === '/getPageLinks') {

--- a/tool.gpt
+++ b/tool.gpt
@@ -1,4 +1,4 @@
-export: browse, getPageContents, getPageImages, click, fill, check, select, enter, scroll, close, screenshot, back, forward
+export: browse, getPageContents, getPageImages, click, fill, check, select, enter, scroll, close, screenshot, back, forward, filter
 description: A toolset that can be used to browse and navigate websites.
 
 ---
@@ -39,6 +39,15 @@ args: tabID: (required) The ID of the tab.
 tools: service
 
 #!http://service.daemon.gptscript.local/click
+
+---
+name: filter
+description: filter the page to get elements based on specific id, html tag, or class.
+args: filter: (required) the class (eg. '.foo') or id (eg. '#foo') of an object.
+args: tabID: (required) The ID of the tab. If unspecified, a new tab will be created.
+tools: service
+
+#!http://service.daemon.gptscript.local/getFilteredContent
 
 ---
 name: fill

--- a/tool.gpt
+++ b/tool.gpt
@@ -44,7 +44,7 @@ tools: service
 name: filter
 description: filter the page to get elements based on specific id, html tag, or class.
 args: filter: (required) the class (eg. '.foo') or id (eg. '#foo') of an object.
-args: tabID: (required) The ID of the tab. If unspecified, a new tab will be created.
+args: tabID: (required) The ID of the tab to filter contents of.
 tools: service
 
 #!http://service.daemon.gptscript.local/getFilteredContent


### PR DESCRIPTION
Some pages end up being way to large to process by the LLM and max out the context windows.

This provides the capability for the Browser tool to grab a specific section of a page based on an HTML tag, Class, or ID items.

I chose to add a new method to avoid changing the signature of the main browse method, but if needed, I can take a pass at combining into the browse method.