### PR TITLE
enhance: override browser settings location with environment variable

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,6 +7,15 @@ export interface BrowserSettings {
 }
 
 export function loadSettingsFile (): BrowserSettings {
+  if (process.env.GPTSCRIPT_BROWSER_SETTINGS_FILE != null) {
+    try {
+      const contents = fs.readFileSync(process.env.GPTSCRIPT_BROWSER_SETTINGS_FILE)
+      return JSON.parse(contents.toString())
+    } catch (e) {
+      return {}
+    }
+  }
+
   const file = process.env.GPTSCRIPT_WORKSPACE_DIR + '/browsersettings.json'
   try {
     const contents = fs.readFileSync(file)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,7 +7,7 @@ export interface BrowserSettings {
 }
 
 export function loadSettingsFile (): BrowserSettings {
-  if (process.env.GPTSCRIPT_BROWSER_SETTINGS_FILE != null) {
+  if (process.env.GPTSCRIPT_BROWSER_SETTINGS_FILE != null && process.env.GPTSCRIPT_BROWSER_SETTINGS_FILE !== '') {
     try {
       const contents = fs.readFileSync(process.env.GPTSCRIPT_BROWSER_SETTINGS_FILE)
       return JSON.parse(contents.toString())


### PR DESCRIPTION
This change makes the browser tool check an environment variable and, if it is set, use it as the path to the browser settings, rather than looking in the workspace directory.

This is needed for gptscript-ai/desktop#321