### PR TITLE
fix: add model provider credential

### DIFF
--- a/tool.gpt
+++ b/tool.gpt
@@ -1,4 +1,5 @@
 export: browse, getPageContents, getPageImages, click, fill, check, select, enter, scroll, close, screenshot, back, forward, filter
+share context: github.com/gptscript-ai/credentials/model-provider
 description: A toolset that can be used to browse and navigate websites.
 
 ---


### PR DESCRIPTION
This fixes the issue where the browser didn't have access to OPENAI_API_KEY in certain circumstances, and would crash with an EOF error when being used over the sdkserver (like with Otto and Desktop).